### PR TITLE
update to allow PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "role": "Developer"
     }],
     "require": {
-        "php": "^7.2"
+        "php": "^7.2 || ^8.0"
     },
     "require-dev": {
         "infection/infection": "^0.13.1",


### PR DESCRIPTION
Simply adds the logical or to allow for PHP 7.2 or PHP 8.0 version(s)